### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/src/lib/models/networks/pose_hrnet.py
+++ b/src/lib/models/networks/pose_hrnet.py
@@ -521,7 +521,7 @@ class PoseHighResolutionNet(nn.Module):
             need_init_state_dict = {}
             for name, m in pretrained_state_dict.items():
                 if name.split('.')[0] in self.pretrained_layers \
-                   or self.pretrained_layers[0] is '*':
+                   or self.pretrained_layers[0] == '*':
                     need_init_state_dict[name] = m
             self.load_state_dict(need_init_state_dict, strict=False)
         elif pretrained:


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise SyntaxWarnings so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

% python3.8
```
>>> '*' is '*'
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
True
```