### PR TITLE
Enable pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,139 @@
 .idea
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -52,7 +52,20 @@ cd DCNv2
 ./make.sh
 ```
 * In order to run the code for demos, you also need to install [ffmpeg](https://www.ffmpeg.org/).
-
+### Lib Installation
+* If using the `lib` in another project you can install it as `fairmot`.
+```sh
+# to install from the root of the cloned repo
+pip install .
+# to install directly from github
+pip install git+https://github.com/ifzhang/FairMOT.git
+```
+* To use the `lib` you may import it as `fairmot`.
+```python
+import fairmot
+import fairmot.tracker.multitracker as mt
+...
+```
 ## Data preparation
 
 * **CrowdHuman**

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,19 @@
+import os
 import setuptools
+from typing import List
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+
+def find_packages_in_package_dir(package_name: str, package_dir: str) -> List[str]:
+    """Finds packages inside package_dir and returns them in the package_name namespace."""
+    packages = []
+    for sub_package in setuptools.find_namespace_packages(package_dir):
+        packages.append(package_name + "." + sub_package)
+
+    return packages
+
 
 setuptools.setup(
     name="fairmot",
@@ -11,7 +23,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ifzhang/FairMOT",
-    packages=["fairmot"],
+    packages=find_packages_in_package_dir("fairmot", "src/lib"),
     package_dir={"fairmot": "src/lib"},
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ifzhang/FairMOT",
-    packages=setuptools.find_packages(),
+    packages=["fairmot"],
     package_dir={"fairmot": "src/lib"},
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,39 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="fairmot",
+    version="0.1.0",
+    author="Yifu Zhang",
+    description="A simple baseline for one-shot multi-object tracking.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/ifzhang/FairMOT",
+    packages=setuptools.find_packages(),
+    package_dir={"fairmot": "src/lib"},
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires=">=3.6",
+    install_requires=[
+        "cython",
+        "cython-bbox",
+        "matplotlib",
+        "motmetrics",
+        "numba",
+        "opencv-python",
+        "openpyxl",
+        "Pillow",
+        "lap",
+        "progress",
+        "scipy",
+        "torch>=1.2.0",
+        "torchvision>=0.4.0",
+        "yacs",
+    ],
+    extras_require={"tensorboard": ["tensorboardX"]},
+)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 def find_packages_in_package_dir(package_name: str, package_dir: str) -> List[str]:
     """Finds packages inside package_dir and returns them in the package_name namespace."""
-    packages = []
+    packages = [package_name]
     for sub_package in setuptools.find_namespace_packages(package_dir):
         packages.append(package_name + "." + sub_package)
 

--- a/src/lib/datasets/dataset/jde.py
+++ b/src/lib/datasets/dataset/jde.py
@@ -15,9 +15,9 @@ import copy
 from torch.utils.data import Dataset
 from torchvision.transforms import transforms as T
 from cython_bbox import bbox_overlaps as bbox_ious
-from opts import opts
-from utils.image import gaussian_radius, draw_umich_gaussian, draw_msra_gaussian
-from utils.utils import xyxy2xywh, generate_anchors, xywh2xyxy, encode_delta
+from fairmot.opts import opts
+from fairmot.utils.image import gaussian_radius, draw_umich_gaussian, draw_msra_gaussian
+from fairmot.utils.utils import xyxy2xywh, generate_anchors, xywh2xyxy, encode_delta
 
 
 class LoadImages:  # for inference

--- a/src/lib/tracker/matching.py
+++ b/src/lib/tracker/matching.py
@@ -5,7 +5,7 @@ import lap
 from scipy.spatial.distance import cdist
 
 from cython_bbox import bbox_overlaps as bbox_ious
-from tracking_utils import kalman_filter
+from fairmot.tracking_utils import kalman_filter
 import time
 
 def merge_matches(m1, m2, shape):

--- a/src/lib/tracker/multitracker.py
+++ b/src/lib/tracker/multitracker.py
@@ -9,17 +9,17 @@ import torch
 import cv2
 import torch.nn.functional as F
 
-from models.model import create_model, load_model
-from models.decode import mot_decode
-from tracking_utils.utils import *
-from tracking_utils.log import logger
-from tracking_utils.kalman_filter import KalmanFilter
-from models import *
-from tracker import matching
+from fairmot.models.model import create_model, load_model
+from fairmot.models.decode import mot_decode
+from fairmot.tracking_utils.utils import *
+from fairmot.tracking_utils.log import logger
+from fairmot.tracking_utils.kalman_filter import KalmanFilter
+from fairmot.models import *
+from fairmot.tracker import matching
 from .basetrack import BaseTrack, TrackState
-from utils.post_process import ctdet_post_process
-from utils.image import get_affine_transform
-from models.utils import _tranpose_and_gather_feat
+from fairmot.utils.post_process import ctdet_post_process
+from fairmot.utils.image import get_affine_transform
+from fairmot.models.utils import _tranpose_and_gather_feat
 
 
 class STrack(BaseTrack):

--- a/src/lib/tracking_utils/evaluation.py
+++ b/src/lib/tracking_utils/evaluation.py
@@ -4,7 +4,7 @@ import copy
 import motmetrics as mm
 mm.lap.default_solver = 'lap'
 
-from tracking_utils.io import read_results, unzip_objs
+from fairmot.tracking_utils.io import read_results, unzip_objs
 
 
 class Evaluator(object):

--- a/src/lib/tracking_utils/io.py
+++ b/src/lib/tracking_utils/io.py
@@ -2,7 +2,7 @@ import os
 from typing import Dict
 import numpy as np
 
-from tracking_utils.log import logger
+from fairmot.tracking_utils.log import logger
 
 
 def write_results(filename, results_dict: Dict, data_type: str):

--- a/src/lib/tracking_utils/nms.py
+++ b/src/lib/tracking_utils/nms.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 # from ._utils import _C
-from tracking_utils import _C
+from fairmot.tracking_utils import _C
 
 nms = _C.nms
 # nms.__doc__ = """

--- a/src/lib/trains/base_trainer.py
+++ b/src/lib/trains/base_trainer.py
@@ -5,8 +5,8 @@ from __future__ import print_function
 import time
 import torch
 from progress.bar import Bar
-from models.data_parallel import DataParallel
-from utils.utils import AverageMeter
+from fairmot.models.data_parallel import DataParallel
+from fairmot.utils.utils import AverageMeter
 
 
 class ModleWithLoss(torch.nn.Module):

--- a/src/lib/trains/mot.py
+++ b/src/lib/trains/mot.py
@@ -10,7 +10,7 @@ import torch.nn.functional as F
 import torchvision
 
 from fairmot.models.losses import FocalLoss, TripletLoss
-from fairmot.odels.losses import RegL1Loss, RegLoss, NormRegL1Loss, RegWeightedL1Loss
+from fairmot.models.losses import RegL1Loss, RegLoss, NormRegL1Loss, RegWeightedL1Loss
 from fairmot.models.decode import mot_decode
 from fairmot.models.utils import _sigmoid, _tranpose_and_gather_feat
 from fairmot.utils.post_process import ctdet_post_process

--- a/src/lib/trains/mot.py
+++ b/src/lib/trains/mot.py
@@ -9,11 +9,11 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torchvision
 
-from models.losses import FocalLoss, TripletLoss
-from models.losses import RegL1Loss, RegLoss, NormRegL1Loss, RegWeightedL1Loss
-from models.decode import mot_decode
-from models.utils import _sigmoid, _tranpose_and_gather_feat
-from utils.post_process import ctdet_post_process
+from fairmot.models.losses import FocalLoss, TripletLoss
+from fairmot.odels.losses import RegL1Loss, RegLoss, NormRegL1Loss, RegWeightedL1Loss
+from fairmot.models.decode import mot_decode
+from fairmot.models.utils import _sigmoid, _tranpose_and_gather_feat
+from fairmot.utils.post_process import ctdet_post_process
 from .base_trainer import BaseTrainer
 
 


### PR DESCRIPTION
## Summary
To make it easier to use the `lib` in other projects I have added a setup.py file. This means users can install the modules inside `src/lib` into their python environment. Additionally, I noticed that there are some `__pycache__` directories in the repo, to avoid any more getting added, I added the github python [default `.gitignore`](https://github.com/github/gitignore/blob/master/Python.gitignore) entries.
### Lib Installation
* To install:
```sh
# to install from the root of the cloned repo
pip install .
# to install directly from github
pip install git+https://github.com/ifzhang/FairMOT.git
```
* To import:
```python
import fairmot
import fairmot.tracker.multitracker as mt
...
```
PS: Great repo, the tracker appears to work very well on my data!