### PR TITLE
heatmap must be input of sigmoid

### DIFF
--- a/src/lib/trains/mot.py
+++ b/src/lib/trains/mot.py
@@ -40,8 +40,8 @@ class MotLoss(torch.nn.Module):
         hm_loss, wh_loss, off_loss, id_loss = 0, 0, 0, 0
         for s in range(opt.num_stacks):
             output = outputs[s]
-            if not opt.mse_loss:
-                output['hm'] = _sigmoid(output['hm'])
+
+            output['hm'] = _sigmoid(output['hm'])
 
             hm_loss += self.crit(output['hm'], batch['hm']) / opt.num_stacks
             if opt.wh_weight > 0:


### PR DESCRIPTION
If we do not apply sigmoid to our heatmap, we will face not good result at test phase( input 0 to 1-> sigmoid -> outout 0.5 to 0.7311).

What do you think of this issue?
