### PR TITLE
Fixing potential bug that can throw IndexError

### DIFF
--- a/src/lib/datasets/dataset/jde.py
+++ b/src/lib/datasets/dataset/jde.py
@@ -439,7 +439,7 @@ class JointDataset(LoadImagesAndLabels):  # for training
         bbox_xys = np.zeros((self.max_objs, 4), dtype=np.float32)
 
         draw_gaussian = draw_msra_gaussian if self.opt.mse_loss else draw_umich_gaussian
-        for k in range(num_objs):
+        for k in range(min(num_objs, self.max_objs)):
             label = labels[k]
             bbox = label[2:]
             cls_id = int(label[0])


### PR DESCRIPTION
In the for-loop we use the same index k to access objects with different sizes. The labels object has size "num_objs" in the first dimension and the rest of the objects (hm, wh, reg, ind, reg_mask, ids, bbox_xys) have size "self.max_objs" in the first dimension. The proposed change should avoid problems in the case where "num_objs" > "self.max_objs".